### PR TITLE
Changes the ordering of the elements of the network URI. Adds display labels

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -59,7 +59,7 @@
           <div class="form-group col-sm-6">
             <label for="chain">Chain</label>
             <select class="form-control" id="chain" name="chain" [(ngModel)]="chain">
-            <option *ngFor="let chain of availableChains" [ngValue]="chain">{{chain}}</option>
+            <option *ngFor="let chain of availableChains" [ngValue]="chain.uri">{{chain.label}}</option>
           </select>
           </div>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,11 +48,24 @@ export class AppComponent implements OnInit {
       gap: this.addressGap
     };
     this.availableOptions = [1, 2, 3, 4, 5, 6];
-    this.availableChains = ['btc/livenet', 'btc/testnet', 'bch/livenet'];
+    this.availableChains = [
+      {
+        label: 'Bitcoin',
+        uri: 'livenet/btc'
+      },
+      {
+        label: 'Bitcoin Testnet',
+        uri: 'testnet/btc',
+      },
+      {
+        label: 'Bitcoin Cash',
+        uri: 'livenet/bch'
+      },
+      ];
     this.fee = 0.0001;
     this.signaturesNumber = this.availableOptions[0];
     this.copayersNumber = this.availableOptions[0];
-    this.chain = this.availableChains[0];
+    this.chain = this.availableChains[0].uri;
     this.statusMessage = null;
     this.successMessage = null;
     this.errorMessage = null;
@@ -95,7 +108,7 @@ export class AppComponent implements OnInit {
       this.network = 'livenet';
       this.coin = 'bch'
     } else {
-      this.network = this.chain.replace('btc/', '');
+      this.network = this.chain.replace('/btc', '');
       this.coin = 'btc'
     }
 

--- a/src/app/services/recovery.service.ts
+++ b/src/app/services/recovery.service.ts
@@ -18,9 +18,9 @@ export class RecoveryService {
   public PATHS: Object;
 
   public apiURI = {
-    'btc/livenet': 'https://insight.bitpay.com/api/',
-    'btc/testnet': 'https://test-insight.bitpay.com/api/',
-    'bch/livenet': 'http://blockdozer.com/insight-api/',
+    'livenet/btc': 'https://insight.bitpay.com/api/',
+    'testnet/btc': 'https://test-insight.bitpay.com/api/',
+    'livenet/bch': 'http://blockdozer.com/insight-api/',
   };
 
 
@@ -30,7 +30,7 @@ export class RecoveryService {
       'BIP44': {
         'testnet': ["m/44'/1'/0'/0", "m/44'/1'/0'/1"],
         'livenet': ["m/44'/0'/0'/0", "m/44'/0'/0'/1"],
-        'bch/livenet': ["m/44'/0'/0'/0", "m/44'/0'/0'/1"]
+        'livenet/bch': ["m/44'/0'/0'/0", "m/44'/0'/0'/1"]
       },
     }
   }


### PR DESCRIPTION
This URI style ('livenet/btc') (vs. other way) matches the style of reverse-domain names (general to more specific).